### PR TITLE
Fixed extra png write, added ability to process multiple inputs

### DIFF
--- a/bin/slice-image
+++ b/bin/slice-image
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import sys
+import os
 import argparse
 from image_slicer import slice, save_tiles, get_basename
 
@@ -9,30 +10,44 @@ def main():
 	"""Parse arguments and slice image."""
 	parser = construct_parser()
 	args = parser.parse_args()
-	tiles = slice(args.image, args.num_tiles)
-	save_tiles(tiles, prefix=get_basename(args.image), directory=args.dir,
-		   format=args.format)
+	for image in args.image:
+
+		if (args.group):
+			out_dir = os.path.join(args.dir, os.path.basename(image))
+		else:
+			out_dir = args.dir
+
+		if not os.path.exists(out_dir):
+			os.makedirs(out_dir)
+
+		tiles = slice(image, args.num_tiles, save=False)
+		save_tiles(tiles, prefix=get_basename(image), directory=out_dir,
+			format=args.format)
 
 def construct_parser():
 	"""Return an ArgumentParser."""
 	parser = argparse.ArgumentParser(prog='slice-image',
-					 description='Slice an image into tiles.',
-					 epilog='Report bugs and make feature requests at https://github.com/samdobson/image_slicer/issues',
-					 add_help=False
-		 )
+					description='Slice an image into tiles.',
+					epilog='Report bugs and make feature requests at https://github.com/samdobson/image_slicer/issues',
+					add_help=False
+		)
 
 	required = parser.add_argument_group('Required Arguments')
-	required.add_argument('image', help='image file')
+	required.add_argument('image', help='image file', nargs='+')
 	required.add_argument('num_tiles', type=int,
-			      help='number of tiles to make')
+						help='number of tiles to make')
 
 	optional = parser.add_argument_group('Optional Arguments')
 	optional.add_argument('-d', '--dir', default='./',
-			      help='output directory')
+						help='output directory')
 	optional.add_argument('-f', '--format', default='png',
-			      help='output image format (e.g JPG, PNG, GIF)')
+						help='output image format (e.g JPG, PNG, GIF)')
 	#parser.add_argument('-e', '--exact', action='store_true',
 	#		    help='Enlarge some tiles to produce the exact number')
+
+	optional.add_argument('-g', '--group', action='store_true', default=False,
+						help='Group output of images in subdirectories'
+		)
 
 	info = parser.add_argument_group('Info')
 	info.add_argument('-h', '--help', action='help',

--- a/image_slicer/main.py
+++ b/image_slicer/main.py
@@ -102,7 +102,7 @@ def slice(filename, number_tiles, save=True):
     Split an image into a specified number of tiles.
 
     Args:
-       filename (str):  The filename of the image to split.
+       filename (str|Image):  The filename of the image to split.
        number_tiles (int):  The number of tiles required.
 
     Kwargs:
@@ -111,7 +111,11 @@ def slice(filename, number_tiles, save=True):
     Returns:
         Tuple of :class:`Tile` instances.
     """
-    im = Image.open(filename)
+    try:
+        im = Image.open(filename)
+    except AttributeError:
+        im = filename
+
     validate_image(im, number_tiles)
 
     im_w, im_h = im.size

--- a/image_slicer/test/test_image_slicer.py
+++ b/image_slicer/test/test_image_slicer.py
@@ -72,7 +72,15 @@ class GeneralTest(unittest.TestCase):
         self.assertEqual(r, expected)
         self.assertEqual(extras(n, r), 6)
 
+class SplitMemoryTest(unittest.TestCase):
 
+    def setUp(self):
+        self.tiles = slice(Image.open(TEST_IMAGE), NUMBER_TILES, save=False)
+
+    def test_tiles_are_images(self):
+        self.assertTrue(all(tile.image.__class__.__name__ == '_ImageCrop')\
+                            for tile in self.tiles)
+        
 class SplitTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
I apologize ahead of time, this merge request combines a bug fix with a feature addition. The bug fix is small though, so if you're inclined to only take that, it should be easy enough for you to apply yourself.
- The bug fix sets sets the `slice` object `save=False` in the cli to prevent two outputs.
- The feature addition is the ability to provide nargs for image inputs. Also, a user can request that outputs be grouped in directories using the `-g` flag.
