### PR TITLE
Allow converting to extensions other than PNG

### DIFF
--- a/image_slicer/main.py
+++ b/image_slicer/main.py
@@ -158,6 +158,7 @@ def save_tiles(tiles, prefix='', directory=os.getcwd(), format='png'):
     for tile in tiles:
         tile.save(filename=tile.generate_filename(prefix=prefix,
                                                   directory=directory,
-                                                  format=format))
+                                                  format=format), 
+                                                  format=format)
     return tuple(tiles)
 


### PR DESCRIPTION
Because `tile.save` is not passing "format" param, PIL is always getting "png" here:
https://github.com/samdobson/image_slicer/blob/4c1a0cfe2a5abca5559faf7e43fecef9749af75e/image_slicer/main.py#L47