### PR TITLE
Fix rows and columns parameters

### DIFF
--- a/bin/slice-image
+++ b/bin/slice-image
@@ -9,9 +9,12 @@ def main():
 	"""Parse arguments and slice image."""
 	parser = construct_parser()
 	args = parser.parse_args()
-	tiles = slice(args.image, args.num_tiles, save=False)
-	save_tiles(tiles, prefix=get_basename(args.image), directory=args.dir,
-		   format=args.format)
+	if args.num_tiles==0 and args.rows == 1 and args.columns == 1:
+		parser.error("No operation specified. You need to either specify the number of tiles to slice automatically, or specify the row and columns to customize the slice.")
+	tiles = slice(args.image, number_tiles=args.num_tiles,
+					row=args.rows, col=args.columns, save=False)
+	save_tiles(tiles, prefix=get_basename(args.image),
+				directory=args.dir, format=args.format)
 
 def construct_parser():
 	"""Return an ArgumentParser."""
@@ -23,16 +26,20 @@ def construct_parser():
 
 	required = parser.add_argument_group('Required Arguments')
 	required.add_argument('image', help='image file')
-	required.add_argument('num_tiles', type=int,
-			      help='number of tiles to make')
 
 	optional = parser.add_argument_group('Optional Arguments')
+	optional.add_argument('-n', '--num-tiles', type=int, default=0,
+						help='Number of tiles to make. Automatically decides the number of rows and columns.')
 	optional.add_argument('-d', '--dir', default='./',
-			      help='output directory')
+						help='output directory')
 	optional.add_argument('-f', '--format', default='png',
-			      help='output image format (e.g JPEG, PNG, GIF)')
+						help='output image format (e.g JPEG, PNG, GIF)')
+	optional.add_argument('-r', "--rows", type=int, default=1,
+						help="Number of rows to divide the image. Used when num_tiles is 0.")
+	optional.add_argument('-c', "--columns", type=int, default=1,
+						help="Number of columns to divide the image. Used when num_tiles is 0.")
 	#parser.add_argument('-e', '--exact', action='store_true',
-	#		    help='Enlarge some tiles to produce the exact number')
+	#			help='Enlarge some tiles to produce the exact number')
 
 	info = parser.add_argument_group('Info')
 	info.add_argument('-h', '--help', action='help',

--- a/image_slicer/main.py
+++ b/image_slicer/main.py
@@ -136,15 +136,14 @@ def slice(filename, number_tiles=None, col=None, row=None, save=True):
 
     columns = 0
     rows = 0
-    if not number_tiles is None:
+    if number_tiles is not None:
         validate_image(im, number_tiles)
         columns, rows = calc_columns_rows(number_tiles)
-        extras = (columns * rows) - number_tiles
+#        extras = (columns * rows) - number_tiles # TODO: not used
     else:
         validate_image_col_row(im, col, row)
         columns = col
         rows = row
-        extras = (columns * rows) - number_tiles
 
 
     tile_w, tile_h = int(floor(im_w / columns)), int(floor(im_h / rows))

--- a/image_slicer/main.py
+++ b/image_slicer/main.py
@@ -133,7 +133,7 @@ def slice(filename, number_tiles=None, col=None, row=None, save=True):
 
     columns = 0
     rows = 0
-    if number_tiles is not None:
+    if number_tiles:
         validate_image(im, number_tiles)
         columns, rows = calc_columns_rows(number_tiles)
 #        extras = (columns * rows) - number_tiles # TODO: not used

--- a/image_slicer/main.py
+++ b/image_slicer/main.py
@@ -107,15 +107,12 @@ def validate_image_col_row(image , col , row):
     except:
         raise ValueError('columns and rows values could not be cast to integer.')
 
-    if col < 2:
-        raise ValueError('Number of columns must be between 2 and {} (you \
-                          asked for {}).'.format(SPLIT_LIMIT, col))
-    if row < 2 :
-        raise ValueError('Number of rows must be between 2 and {} (you \
-                          asked for {}).'.format(SPLIT_LIMIT, row))
-
-
-
+    if col < 1 or row < 1\
+        or col > SPLIT_LIMIT or row > SPLIT_LIMIT:
+        raise ValueError('Number of columns and rows must be between 1 and {} (you \
+                          asked for rows: {} and col: {}).'.format(SPLIT_LIMIT, row, col))
+    if col == 1 and row == 1:
+        raise ValueError('There is nothing to divide. You asked for the entire image.')
 
 def slice(filename, number_tiles=None, col=None, row=None, save=True):
     """


### PR DESCRIPTION
The extra parameter was not being used, so I left one reference, and deleted the reference that prevented me from specifying the number of rows and columns to divide the file.

These could be handy for the command line binary too.