### PR TITLE
Fix so that join works

### DIFF
--- a/bin/join-tiles
+++ b/bin/join-tiles
@@ -16,6 +16,5 @@ parser.add_argument('-v', '--version', action='version',
 		    version='%(prog)s 0.1')
 args = parser.parse_args()
 
-image = join_tiles(open_images_in(args.dir))
+image = join(open_images_in(args.dir))
 image.save('joined.%s'.format(args.format))
-

--- a/image_slicer/helpers.py
+++ b/image_slicer/helpers.py
@@ -2,6 +2,7 @@
 Helper functions for ``image_slicer``.
 '''
 import os
+from PIL import Image
 
 
 def get_basename(filename):
@@ -10,7 +11,8 @@ def get_basename(filename):
 
 def open_images(directory):
     """Open all images in a directory. Return tuple of Image instances."""
-    return [Image.open(file) for file in os.listdir(directory)]
+    return [Image.open(os.path.join(directory, file)) for file in os.listdir(directory)]
+
 
 def get_columns_rows(filenames):
     """Derive number of columns and rows from filenames."""
@@ -21,4 +23,3 @@ def get_columns_rows(filenames):
     rows = [pos[0] for pos in tiles]; columns = [pos[1] for pos in tiles]
     num_rows = max(rows); num_columns = max(columns)
     return (num_columns, num_rows)
-


### PR DESCRIPTION
join-tiles 
- Modified join-tiles to invoke join correctly

helpers.py 
- Added `from PIL import Image`

main.py 
- Implement open_images_in, which returns a tuple of Tiles, so has to go in main.py and can not go into helpers.py
- Allow optional width and height to be specified in join. This is needed when there are missing tiles. The location of the missing tiles is then blacked out in the final image, and the final image can be constructed at the correct size