### PR TITLE
Add Kwarg to slice function to supress Pillow DecompressionBombWarning

### DIFF
--- a/image_slicer/main.py
+++ b/image_slicer/main.py
@@ -131,7 +131,8 @@ def validate_image_col_row(image , col , row):
 
 
 
-def slice(filename, number_tiles=None, col=None, row=None, save=True):
+def slice(filename, number_tiles=None, col=None, row=None, 
+          save=True, DecompressionBombWarning=True):
     """
     Split an image into a specified number of tiles.
 
@@ -141,10 +142,14 @@ def slice(filename, number_tiles=None, col=None, row=None, save=True):
 
     Kwargs:
        save (bool): Whether or not to save tiles to disk.
+       DecompressionBombWarning (bool): Whether to suppress Pillow DecompressionBombWarning
 
     Returns:
         Tuple of :class:`Tile` instances.
     """
+    if DecompressionBombWarning is False:
+        Image.MAX_IMAGE_PIXELS = None
+    
     im = Image.open(filename)
     im_w, im_h = im.size
 


### PR DESCRIPTION
When using the slice function with an image over a certain limit Pillow will throw an [error](https://pillow.readthedocs.io/en/4.0.x/reference/Image.html#functions) when opening the image because of a possible “decompression bomb". 

It might be nice to add an option to supress this warning so it is possible to work with large images of known origin? 

I checked this change worked okay for a number of images but this might not be the best way to implement this option. 