### PR TITLE
An invert feature for the slice operation

### DIFF
--- a/image_slicer/main.py
+++ b/image_slicer/main.py
@@ -129,7 +129,7 @@ def validate_image_col_row(image , col , row):
         raise ValueError('There is nothing to divide. You asked for the entire image.')
 
 def slice(filename, number_tiles=None, col=None, row=None, 
-          save=True, DecompressionBombWarning=True):
+          save=True, DecompressionBombWarning=True,invert = False):
     """
     Split an image into a specified number of tiles.
 
@@ -146,6 +146,9 @@ def slice(filename, number_tiles=None, col=None, row=None,
     """
     if DecompressionBombWarning is False:
         Image.MAX_IMAGE_PIXELS = None
+
+    if invert is True:
+        im = im.rotate(90)
     
     im = Image.open(filename)
     im_w, im_h = im.size


### PR DESCRIPTION
When I was using the slice operation I came across a problem. I was working with a dataset that had the images in the dimensions 3000x4000. I needed to split them into 12 parts of dimensions 1000x1000 but now when I used the image slicer with 12 it gave me 750 x 1350 so I realized if I rotated my image I got 1000x1000 images. Hence added this feature and called it invert because rotate didn't seem apt.